### PR TITLE
disable built-in prometheus and md monitoring

### DIFF
--- a/core-services/core_services.tf
+++ b/core-services/core_services.tf
@@ -33,14 +33,16 @@ module "cluster-autoscaler" {
   release            = "aws-cluster-autoscaler"
   namespace          = "kube-system"
   helm_additional_values = {
-    serviceMonitor = {
-      enabled   = true
-      namespace = "kube-system"
-      selector  = var.md_metadata.default_tags
-    }
+    # disabled for removing prometheus
+    # serviceMonitor = {
+    #   enabled   = true
+    #   namespace = "kube-system"
+    #   selector  = var.md_metadata.default_tags
+    # }
   }
 
-  depends_on = [module.prometheus-observability]
+# disabled for removing prometheus
+  # depends_on = [module.prometheus-observability]
 }
 
 module "ingress_nginx" {
@@ -52,12 +54,13 @@ module "ingress_nginx" {
   namespace          = kubernetes_namespace_v1.md-core-services.metadata.0.name
   helm_additional_values = {
     controller = {
-      metrics = {
-        enabled = true
-        serviceMonitor = {
-          enabled = true
-        }
-      }
+      # disabled for removing prometheus
+      # metrics = {
+      #   enabled = true
+      #   serviceMonitor = {
+      #     enabled = true
+      #   }
+      # }
       service = {
         annotations = {
           "service.beta.kubernetes.io/aws-load-balancer-backend-protocol"                  = "tcp"
@@ -69,7 +72,8 @@ module "ingress_nginx" {
     }
   }
 
-  depends_on = [module.prometheus-observability]
+  # disabled for removing prometheus
+  # depends_on = [module.prometheus-observability]
 }
 
 module "external_dns" {
@@ -81,7 +85,8 @@ module "external_dns" {
   namespace            = kubernetes_namespace_v1.md-core-services.metadata.0.name
   route53_hosted_zones = local.route53_zone_to_domain_map
 
-  depends_on = [module.prometheus-observability]
+  # disabled for removing prometheus
+  # depends_on = [module.prometheus-observability]
 }
 
 module "cert_manager" {
@@ -93,7 +98,8 @@ module "cert_manager" {
   namespace            = kubernetes_namespace_v1.md-core-services.metadata.0.name
   route53_hosted_zones = local.route53_zone_to_domain_map
 
-  depends_on = [module.prometheus-observability]
+  # disabled for removing prometheus
+  # depends_on = [module.prometheus-observability]
 }
 
 module "efs_csi" {
@@ -106,5 +112,6 @@ module "efs_csi" {
   namespace                    = kubernetes_namespace_v1.md-core-services.metadata.0.name
   storage_class_to_efs_arn_map = local.storage_class_to_efs_arn_map
 
-  depends_on = [module.prometheus-observability]
+  # disabled for removing prometheus
+  # depends_on = [module.prometheus-observability]
 }

--- a/core-services/monitoring.tf
+++ b/core-services/monitoring.tf
@@ -1,30 +1,31 @@
-module "alarm_channel" {
-  count       = true ? 1 : 0
-  source      = "github.com/massdriver-cloud/terraform-modules//k8s/alarm-channel?ref=b4c1dda"
-  md_metadata = var.md_metadata
-  namespace   = kubernetes_namespace_v1.md-observability.metadata.0.name
-  release     = var.md_metadata.name_prefix
+# disabled for removing prometheus
+# module "alarm_channel" {
+#   count       = true ? 1 : 0
+#   source      = "github.com/massdriver-cloud/terraform-modules//k8s/alarm-channel?ref=b4c1dda"
+#   md_metadata = var.md_metadata
+#   namespace   = kubernetes_namespace_v1.md-observability.metadata.0.name
+#   release     = var.md_metadata.name_prefix
 
-  depends_on = [module.prometheus-observability]
-}
+#   depends_on = [module.prometheus-observability]
+# }
 
-module "application_alarms" {
-  count             = true ? 1 : 0
-  source            = "github.com/massdriver-cloud/terraform-modules//massdriver/k8s-application-alarms?ref=b4c1dda"
-  md_metadata       = var.md_metadata
-  pod_alarms        = true
-  deployment_alarms = true
-  daemonset_alarms  = true
+# module "application_alarms" {
+#   count             = true ? 1 : 0
+#   source            = "github.com/massdriver-cloud/terraform-modules//massdriver/k8s-application-alarms?ref=b4c1dda"
+#   md_metadata       = var.md_metadata
+#   pod_alarms        = true
+#   deployment_alarms = true
+#   daemonset_alarms  = true
 
-  depends_on = [module.prometheus-observability]
-}
+#   depends_on = [module.prometheus-observability]
+# }
 
-module "cluster_autoscaler_max_scale" {
-  count                 = true ? 1 : 0
-  source                = "github.com/massdriver-cloud/terraform-modules//k8s/prometheus-alarm?ref=b4c1dda"
-  md_metadata           = var.md_metadata
-  display_name          = "Cluster Autoscaler Max Scale"
-  prometheus_alert_name = "ClusterAutoscalerUnschedulablePods"
+# module "cluster_autoscaler_max_scale" {
+#   count                 = true ? 1 : 0
+#   source                = "github.com/massdriver-cloud/terraform-modules//k8s/prometheus-alarm?ref=b4c1dda"
+#   md_metadata           = var.md_metadata
+#   display_name          = "Cluster Autoscaler Max Scale"
+#   prometheus_alert_name = "ClusterAutoscalerUnschedulablePods"
 
-  depends_on = [module.prometheus-observability]
-}
+#   depends_on = [module.prometheus-observability]
+# }

--- a/core-services/observability.tf
+++ b/core-services/observability.tf
@@ -1,73 +1,74 @@
-resource "kubernetes_namespace_v1" "md-observability" {
-  metadata {
-    labels = var.md_metadata.default_tags
-    name   = "md-observability"
-  }
-}
+# disabled for removing prometheus
+# resource "kubernetes_namespace_v1" "md-observability" {
+#   metadata {
+#     labels = var.md_metadata.default_tags
+#     name   = "md-observability"
+#   }
+# }
 
-// Making this a hard-coded conditional for now, because once we support prometheus it will become conditional based on prometheus
-// since it is effectively replaced by the prometheus-adapter https://github.com/kubernetes-sigs/prometheus-adapter
-module "metrics-server" {
-  count       = true ? 1 : 0
-  source      = "github.com/massdriver-cloud/terraform-modules//k8s-metrics-server?ref=b4c1dda"
-  md_metadata = var.md_metadata
-  release     = "metrics-server"
-  namespace   = kubernetes_namespace_v1.md-observability.metadata.0.name
+# // Making this a hard-coded conditional for now, because once we support prometheus it will become conditional based on prometheus
+# // since it is effectively replaced by the prometheus-adapter https://github.com/kubernetes-sigs/prometheus-adapter
+# module "metrics-server" {
+#   count       = true ? 1 : 0
+#   source      = "github.com/massdriver-cloud/terraform-modules//k8s-metrics-server?ref=b4c1dda"
+#   md_metadata = var.md_metadata
+#   release     = "metrics-server"
+#   namespace   = kubernetes_namespace_v1.md-observability.metadata.0.name
 
-  depends_on = [module.prometheus-observability]
-}
+#   depends_on = [module.prometheus-observability]
+# }
 
-module "prometheus-observability" {
-  count       = true ? 1 : 0
-  source      = "github.com/massdriver-cloud/terraform-modules//massdriver/k8s-prometheus-observability?ref=b4c1dda"
-  md_metadata = var.md_metadata
-  release     = "massdriver"
-  namespace   = kubernetes_namespace_v1.md-observability.metadata.0.name
-  helm_additional_values = {
-    prometheus = {
-      prometheusSpec = {
-        storageSpec = lookup(var.monitoring.prometheus, "persistence_enabled", false) ? {} : null
-      }
-    }
-    prometheus-node-exporter = {
-      affinity = {
-        nodeAffinity = {
-          requiredDuringSchedulingIgnoredDuringExecution = {
-            nodeSelectorTerms = [{
-              matchExpressions = [{
-                key      = "eks.amazonaws.com/compute-type"
-                operator = "NotIn"
-                values   = ["fargate"]
-              }]
-            }]
-          }
-        }
-      }
-    }
-    grafana = {
-      enabled       = lookup(var.monitoring.prometheus, "grafana_enabled", false)
-      adminPassword = lookup(var.monitoring.prometheus, "grafana_password", "prom-operator")
-    }
-  }
+# module "prometheus-observability" {
+#   count       = true ? 1 : 0
+#   source      = "github.com/massdriver-cloud/terraform-modules//massdriver/k8s-prometheus-observability?ref=b4c1dda"
+#   md_metadata = var.md_metadata
+#   release     = "massdriver"
+#   namespace   = kubernetes_namespace_v1.md-observability.metadata.0.name
+#   helm_additional_values = {
+#     prometheus = {
+#       prometheusSpec = {
+#         storageSpec = lookup(var.monitoring.prometheus, "persistence_enabled", false) ? {} : null
+#       }
+#     }
+#     prometheus-node-exporter = {
+#       affinity = {
+#         nodeAffinity = {
+#           requiredDuringSchedulingIgnoredDuringExecution = {
+#             nodeSelectorTerms = [{
+#               matchExpressions = [{
+#                 key      = "eks.amazonaws.com/compute-type"
+#                 operator = "NotIn"
+#                 values   = ["fargate"]
+#               }]
+#             }]
+#           }
+#         }
+#       }
+#     }
+#     grafana = {
+#       enabled       = lookup(var.monitoring.prometheus, "grafana_enabled", false)
+#       adminPassword = lookup(var.monitoring.prometheus, "grafana_password", "prom-operator")
+#     }
+#   }
 
-  // prometheus requires persistent storage, which is managed by the EBS addon. This is more important on destruction since
-  // volumes won't unbind properly if the EBS CSI driver is uninstalled before the volume, blocking destruction indefinitely.
-  depends_on = [module.ebs_csi]
-}
+#   // prometheus requires persistent storage, which is managed by the EBS addon. This is more important on destruction since
+#   // volumes won't unbind properly if the EBS CSI driver is uninstalled before the volume, blocking destruction indefinitely.
+#   depends_on = [module.ebs_csi]
+# }
 
-module "prometheus-rules" {
-  count       = true ? 1 : 0
-  source      = "github.com/massdriver-cloud/terraform-modules//massdriver/k8s-prometheus-rules?ref=b4c1dda"
-  md_metadata = var.md_metadata
-  release     = "massdriver"
-  namespace   = kubernetes_namespace_v1.md-observability.metadata.0.name
-  helm_additional_values = {
-    defaultRules = {
-      rules = {
-        clusterAutoscaler = true
-      }
-    }
-  }
+# module "prometheus-rules" {
+#   count       = true ? 1 : 0
+#   source      = "github.com/massdriver-cloud/terraform-modules//massdriver/k8s-prometheus-rules?ref=b4c1dda"
+#   md_metadata = var.md_metadata
+#   release     = "massdriver"
+#   namespace   = kubernetes_namespace_v1.md-observability.metadata.0.name
+#   helm_additional_values = {
+#     defaultRules = {
+#       rules = {
+#         clusterAutoscaler = true
+#       }
+#     }
+#   }
 
-  depends_on = [module.prometheus-observability]
-}
+#   depends_on = [module.prometheus-observability]
+# }

--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -29,11 +29,11 @@ params:
         enable_ingress: true
         route53_hosted_zones: []
         enable_efs_csi: false
-      monitoring:
-        control_plane_log_retention: 7
-        prometheus:
-          persistence_enabled: false
-          grafana_enabled: false
+      # monitoring:
+      #   control_plane_log_retention: 7
+      #   prometheus:
+      #     persistence_enabled: false
+      #     grafana_enabled: false
     - __name: Development
       k8s_version: "1.30"
       node_groups:
@@ -41,11 +41,11 @@ params:
           instance_type: t3.medium
           min_size: 1
           max_size: 10
-      monitoring:
-        control_plane_log_retention: 7
-        prometheus:
-          persistence_enabled: false
-          grafana_enabled: false
+        # monitoring:
+        #   control_plane_log_retention: 7
+        #   prometheus:
+        #     persistence_enabled: false
+        #     grafana_enabled: false
     - __name: Production
       k8s_version: "1.30"
       node_groups:
@@ -53,16 +53,16 @@ params:
           instance_type: c5.2xlarge
           min_size: 1
           max_size: 10
-      monitoring:
-        control_plane_log_retention: 365
-        prometheus:
-          persistence_enabled: true
-          grafana_enabled: false
+      # monitoring:
+      #   control_plane_log_retention: 365
+      #   prometheus:
+      #     persistence_enabled: true
+      #     grafana_enabled: false
   required:
     - k8s_version
     - node_groups
     - core_services
-    - monitoring
+    # - monitoring
 
   properties:
     k8s_version:
@@ -281,65 +281,65 @@ params:
                         pattern: ^arn:aws:elasticfilesystem:[a-z0-9-]*:(?:[0-9]{12})?:file-system\/fs-(?:[a-z0-9]+)?$
                         message:
                           pattern: Must be a valid AWS EFS file system ARN
-    monitoring:
-      type: object
-      title: Monitoring
-      required:
-        - control_plane_log_retention
-        - prometheus
-      properties:
-        control_plane_log_retention:
-          type: integer
-          title: Control Plane Log Retention
-          description: "Duration to retain control plane logs in AWS Cloudwatch (Note: control plane logs do not contain application or container logs)"
-          default: 7
-          oneOf:
-            - title: 7 days
-              const: 7
-            - title: 30 days
-              const: 30
-            - title: 90 days
-              const: 60
-            - title: 180 days
-              const: 180
-            - title: 1 year
-              const: 365
-            - title: Never expire
-              const: 0
-        prometheus:
-          type: object
-          title: Prometheus Configuration
-          description: Configuration settings for the Prometheus instances that are automatically installed into the cluster to provide monitoring capabilities"
-          required:
-            - persistence_enabled
-            - grafana_enabled
-          properties:
-            persistence_enabled:
-              title: Enable Persistence
-              type: boolean
-              description: This setting will enable persistence of Prometheus data via EBS volumes. However, in small clusters (less than 5 nodes) this can create problems of pod scheduling and placement due EBS volumes being zonally-locked, and thus should be disabled.
-              default: true
-            grafana_enabled:
-              title: Enable Grafana
-              type: boolean
-              description: Install Grafana into the cluster to provide a metric visualizer
-              default: false
-          dependencies:
-            grafana_enabled:
-              oneOf:
-                - properties:
-                    grafana_enabled:
-                      const: false
-                - properties:
-                    grafana_enabled:
-                      const: true
-                    grafana_password:
-                      title: Grafana Admin Password
-                      description: Set the password for the `admin` user
-                      type: string
-                      format: password
-                  required:
-                    - grafana_password
+    # monitoring:
+    #   type: object
+    #   title: Monitoring
+    #   required:
+    #     - control_plane_log_retention
+    #     - prometheus
+    #   properties:
+    #     control_plane_log_retention:
+    #       type: integer
+    #       title: Control Plane Log Retention
+    #       description: "Duration to retain control plane logs in AWS Cloudwatch (Note: control plane logs do not contain application or container logs)"
+    #       default: 7
+    #       oneOf:
+    #         - title: 7 days
+    #           const: 7
+    #         - title: 30 days
+    #           const: 30
+    #         - title: 90 days
+    #           const: 60
+    #         - title: 180 days
+    #           const: 180
+    #         - title: 1 year
+    #           const: 365
+    #         - title: Never expire
+    #           const: 0
+    #     prometheus:
+    #       type: object
+    #       title: Prometheus Configuration
+    #       description: Configuration settings for the Prometheus instances that are automatically installed into the cluster to provide monitoring capabilities"
+    #       required:
+    #         - persistence_enabled
+    #         - grafana_enabled
+    #       properties:
+    #         persistence_enabled:
+    #           title: Enable Persistence
+    #           type: boolean
+    #           description: This setting will enable persistence of Prometheus data via EBS volumes. However, in small clusters (less than 5 nodes) this can create problems of pod scheduling and placement due EBS volumes being zonally-locked, and thus should be disabled.
+    #           default: true
+    #         grafana_enabled:
+    #           title: Enable Grafana
+    #           type: boolean
+    #           description: Install Grafana into the cluster to provide a metric visualizer
+    #           default: false
+    #       dependencies:
+    #         grafana_enabled:
+    #           oneOf:
+    #             - properties:
+    #                 grafana_enabled:
+    #                   const: false
+    #             - properties:
+    #                 grafana_enabled:
+    #                   const: true
+    #                 grafana_password:
+    #                   title: Grafana Admin Password
+    #                   description: Set the password for the `admin` user
+    #                   type: string
+    #                   format: password
+    #               required:
+    #                 - grafana_password
 
 connections:
   required:
@@ -364,7 +364,7 @@ ui:
     - fargate
     - node_groups
     - core_services
-    - monitoring
+    # - monitoring
     - "*"
   k8s_version:
     ui:field: versioningDropdown
@@ -392,12 +392,12 @@ ui:
         ui:order:
           - storage_class_name
           - efs_arn
-  monitoring:
-    ui:order:
-      - control_plane_log_retention
-      - prometheus
-    prometheus:
-      ui:order:
-        - persistence_enabled
-        - grafana_enabled
-        - grafana_password
+  # monitoring:
+  #   ui:order:
+  #     - control_plane_log_retention
+  #     - prometheus
+    # prometheus:
+    #   ui:order:
+    #     - persistence_enabled
+    #     - grafana_enabled
+    #     - grafana_password


### PR DESCRIPTION
Allows installation of custom prometheus (e.g. AWS Managed Prometheus, Grafana Cloud, etc.)